### PR TITLE
fix demo for mac osx

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ and also provides a more Pythonic API.
 
 * Windows/Linux/OSX
 * Python 2.7.x
+* distribute (a fork of the Setuptools project)
 * librtlsdr (builds dated after 5/5/12)
 * **Optional**: NumPy (wraps samples in a more convenient form)
 

--- a/demo_waterfall.py
+++ b/demo_waterfall.py
@@ -3,6 +3,7 @@ import matplotlib.animation as animation
 from matplotlib.mlab import psd
 import pylab as pyl
 import numpy as np
+import sys
 from rtlsdr import RtlSdr
 
 # A simple waterfall, spectrum plotter
@@ -127,7 +128,15 @@ class Waterfall(object):
 
     def start(self):
         self.update_plot_labels()
-        ani = animation.FuncAnimation(self.fig, self.update, interval=50, blit=True)
+        if sys.platform == 'darwin':
+            # Disable blitting. The matplotlib.animation's restore_region()
+            # method is only implemented for the Agg-based backends,
+            # which the macosx backend is not.
+            blit = False
+        else:
+            blit = True
+        ani = animation.FuncAnimation(self.fig, self.update, interval=50,
+                blit=blit)
 
         pyl.show()
 


### PR DESCRIPTION
The demo `demo_waterfall.py` do not work with mac osx:

```
Traceback (most recent call last):
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.6/lib/python2.6/site-packages/matplotlib/backend_bases.py", line 1092, in _on_timer
    ret = func(*args, **kwargs)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.6/lib/python2.6/site-packages/matplotlib/animation.py", line 315, in _step
    still_going = Animation._step(self, *args)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.6/lib/python2.6/site-packages/matplotlib/animation.py", line 177, in _step
    self._draw_next_frame(framedata, self._blit)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.6/lib/python2.6/site-packages/matplotlib/animation.py", line 195, in _draw_next_frame
    self._pre_draw(framedata, blit)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.6/lib/python2.6/site-packages/matplotlib/animation.py", line 208, in _pre_draw
    self._blit_clear(self._drawn_artists, self._blit_cache)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.6/lib/python2.6/site-packages/matplotlib/animation.py", line 248, in _blit_clear
    a.figure.canvas.restore_region(bg_cache[a])
AttributeError: 'FigureCanvasMac' object has no attribute 'restore_region'
```

Since the matplotlib.animation's blitting do not work in mac osx[1][2], I disable it and run the demo succeed. 

[1] http://comments.gmane.org/gmane.comp.python.epd.user/486
[2] http://www.digipedia.pl/usenet/thread/15998/29360/
