### PR TITLE
Added automatic dependency installation for Linux and Windows.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,6 +151,8 @@ sdist
 develop-eggs
 .installed.cfg
 venv/
+pyrtlsdr_temp/
+.gitignore~
 
 # Installer logs
 pip-log.txt

--- a/.gitignore
+++ b/.gitignore
@@ -150,6 +150,7 @@ var
 sdist
 develop-eggs
 .installed.cfg
+venv/
 
 # Installer logs
 pip-log.txt

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ pyrtlsdr can be installed by downloading the source files and running `python se
 ###Windows
 Clone this repository. Depending on python version download and copy files in either `x32` or `x64` subdirectories 
 of [this zip file](http://sdr.osmocom.org/trac/attachment/wiki/rtl-sdr/RelWithDebInfo.zip) into the package directory
- directory of pyrtlsdr (e.g. location_to_clone\pyrtlsdr\rtlsdr).  
+ of pyrtlsdr (e.g. location_to_clone\pyrtlsdr\rtlsdr).  
   
 ###Linux
 Clone this repository. Install `rtl-sdr`:  

--- a/README.md
+++ b/README.md
@@ -9,21 +9,18 @@ and also provides a more Pythonic API.
 
 ##Installation
 
-pyrtlsdr can be installed by downloading the source files and running `python setup.py install`.
-
-##Manual Installation
-###Windows
-Clone this repository. Depending on python version download and copy files in either `x32` or `x64` subdirectories 
-of [this zip file](http://sdr.osmocom.org/trac/attachment/wiki/rtl-sdr/RelWithDebInfo.zip) into the package directory
- of pyrtlsdr (e.g. location_to_clone\pyrtlsdr\rtlsdr).  
+`pyrtlsdr` can be installed by downloading the source files and running 
+```
+$ python setup.py install
+```
+This will install the python wrapper around `librtlsdr`. You will need to build `librtlsdr` from source yourself.  
   
-###Linux
-Clone this repository. Install `rtl-sdr`:  
+A simpler installation can be done by passing the argument `--simple-install`. This downloads/installs `librtlsdr` libraries and 
+`rtl-sdr` executables in the package installation directory. However, the installed libraries may not be fully up to date.
 ```
-$ sudo apt-get install rtl-sdr
+$ python setup.py install --simple-install
 ```
-
-
+  
 All functions in librtlsdr are accessible via librtlsdr.py and a Pythonic interface is available in rtlsdr.py (recommended).
 Some documentation can be found in docstrings in the latter file.
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,22 @@ and also provides a more Pythonic API.
 
 # Usage
 
-pyrtlsdr can be installed by downloading the source files and running `python setup.py install`, or using [pip](http://www.pip-installer.org/en/latest/) and
-`pip install pyrtlsdr`.
+##Installation
+
+pyrtlsdr can be installed by downloading the source files and running `python setup.py install`.
+
+##Manual Installation
+###Windows
+Clone this repository. Depending on python version download and copy files in either `x32` or `x64` subdirectories 
+of [this zip file](http://sdr.osmocom.org/trac/attachment/wiki/rtl-sdr/RelWithDebInfo.zip) into the package directory
+ directory of pyrtlsdr (e.g. location_to_clone\pyrtlsdr\rtlsdr).  
+  
+###Linux
+Clone this repository. Install `rtl-sdr`:  
+```
+$ sudo apt-get install rtl-sdr
+```
+
 
 All functions in librtlsdr are accessible via librtlsdr.py and a Pythonic interface is available in rtlsdr.py (recommended).
 Some documentation can be found in docstrings in the latter file.

--- a/pre_install.py
+++ b/pre_install.py
@@ -45,6 +45,7 @@ def win_setup(cleanup=False):
     
     if cleanup:
         shutil.rmtree(TEMP_DIR)
+        return
     
     print('Downloading dependencies...')
     response = url.urlretrieve(WIN_ZIP_URL, TEMP_FILE)

--- a/pre_install.py
+++ b/pre_install.py
@@ -1,0 +1,78 @@
+﻿# Post install script to get dependencies
+
+import os
+import sys
+import zipfile
+import platform
+import shutil
+from subprocess import call
+
+MIN_PYTHON_2_VERSION = (2,7)
+MIN_PYTHON_3_VERSION = (3,3)
+SYS_VERSION = sys.version_info
+
+if (SYS_VERSION < MIN_PYTHON_2_VERSION) or (SYS_VERSION >= (3,0) and SYS_VERSION < (3,3)):
+    print('Please upgrade to python versions: ' + MIN_PYTHON_2_VERSION + ' or ' + MIN_PYTHON_3_VERSION + '.')
+    sys.exit(1)
+elif SYS_VERSION >= MIN_PYTHON_3_VERSION:
+    # python 3.3+ imports
+    import urllib as url
+elif SYS_VERSION >= MIN_PYTHON_2_VERSION:
+    # python 2.7.x imports
+    import urllib as url
+
+
+def get_data_files():
+    operating_sys = platform.system()
+    if operating_sys == 'Windows':
+        return win_setup()
+    elif operating_sys == 'Linux':
+        return linux_setup()
+
+
+def win_setup(cleanup=False):
+    '''Download, extract, and copy required DLL  and EXE files to package installation directory for Windows
+    '''
+    
+    cwd = os.getcwd()
+    WIN_ZIP_URL = 'http://sdr.osmocom.org/trac/raw-attachment/wiki/rtl-sdr/RelWithDebInfo.zip'
+    ARCHITECTURE = platform.architecture()[0]
+    ZIP_PATH = 'rtl-sdr-release/'
+    ZIP_PATH += 'x64' if ARCHITECTURE == '64bit' else 'x32'
+    TEMP_DIR = 'pyrtlsdr_temp\\'
+    TEMP_FILE = 'temp.zip'
+    MANIFEST_PATH = cwd + '\\MANIFEST.in'
+    
+    if cleanup:
+        shutil.rmtree(TEMP_DIR)
+    
+    print('Downloading dependencies...')
+    response = url.urlretrieve(WIN_ZIP_URL, TEMP_FILE)
+    zip_file = zipfile.ZipFile(TEMP_FILE, 'r')
+    
+    print('Unzipping dependencies...')
+    file_list = []
+    for file in zip_file.namelist():
+        if file.startswith(ZIP_PATH):
+            file_list.append(file)
+            zip_file.extract(file, TEMP_DIR)
+    
+    zip_file.close()
+    os.remove(TEMP_FILE)
+    print('Extracted.')
+    
+    file_list = [('rtlsdr', [os.path.normpath(TEMP_DIR + file)]) for file in file_list][1:]
+    return file_list
+ 
+
+def linux_setup():
+    '''Get required dependencies for a linux installation.
+    '''
+    print('Installing library rtl-sdr...')
+    call('sudo apt-get install rtl-sdr', shell=True)
+    return None
+    
+ 
+
+if __name__ == '__main__':
+    get_data_files()

--- a/pre_install.py
+++ b/pre_install.py
@@ -1,4 +1,4 @@
-﻿# Post install script to get dependencies
+﻿# Pre-install script to get dependencies
 
 import os
 import sys

--- a/rtlsdr/librtlsdr.py
+++ b/rtlsdr/librtlsdr.py
@@ -28,7 +28,7 @@ def load_librtlsdr():
         os.environ['PATH']  += os.pathsep + curr_path
     
     driver_files = ['rtlsdr.dll', 'librtlsdr.so']
-    driver_files += [curr_path + os.path.sep + 'rtlsdr.dll', curr_path + os.path.sep + 'librtlsdr.so']
+    driver_files += ['..//rtlsdr.dll', '..//librtlsdr.so']
     driver_files += ['rtlsdr//rtlsdr.dll', 'rtlsdr//librtlsdr.so']
     driver_files += [find_library('rtlsdr'), find_library('librtlsdr')]
 

--- a/rtlsdr/librtlsdr.py
+++ b/rtlsdr/librtlsdr.py
@@ -17,10 +17,16 @@
 
 from ctypes import *
 from ctypes.util import find_library
+import os
 
 def load_librtlsdr():
+    
+    # make sure that .DLL dependencies are accessible
+    curr_path = os.path.dirname(__file__)
+    os.environ['PATH']  += os.pathsep + curr_path
+    
     driver_files = ['rtlsdr.dll', 'librtlsdr.so']
-    driver_files += ['..//rtlsdr.dll', '..//librtlsdr.so']
+    driver_files += [curr_path + os.path.sep + 'rtlsdr.dll', curr_path + os.path.sep + 'librtlsdr.so']
     driver_files += ['rtlsdr//rtlsdr.dll', 'rtlsdr//librtlsdr.so']
     driver_files += [find_library('rtlsdr'), find_library('librtlsdr')]
 

--- a/rtlsdr/librtlsdr.py
+++ b/rtlsdr/librtlsdr.py
@@ -18,12 +18,14 @@
 from ctypes import *
 from ctypes.util import find_library
 import os
+import platform
 
 def load_librtlsdr():
     
-    # make sure that .DLL dependencies are accessible
-    curr_path = os.path.dirname(__file__)
-    os.environ['PATH']  += os.pathsep + curr_path
+    if platform.system() == 'Windows':
+        # make sure that .DLL dependencies are accessible
+        curr_path = os.path.dirname(__file__)
+        os.environ['PATH']  += os.pathsep + curr_path
     
     driver_files = ['rtlsdr.dll', 'librtlsdr.so']
     driver_files += [curr_path + os.path.sep + 'rtlsdr.dll', curr_path + os.path.sep + 'librtlsdr.so']

--- a/setup.py
+++ b/setup.py
@@ -42,13 +42,24 @@ else:
 #README = open(os.path.join(HERE, 'README.md')).read()
 
 # PRE INSTALLATION SCRIPT
-print('Running pre-installation script...')
-try:
-    DATA_FILES = pre_install.get_data_files()
-except Exception as e:
-    DATA_FILES = None
-    print('Dependency extraction failed. Please copy required files manually.')
+if '--simple-install' in sys.argv:
+    SIMPLE_INSTALL = True
+    del sys.argv[sys.argv.index('--simple-install')]       # remove argument so not to disrupt setup()
+else: 
+    SIMPLE_INSTALL = False
 
+
+if SIMPLE_INSTALL:
+    print('Running pre-installation script...')
+    try:
+        DATA_FILES = pre_install.get_data_files()
+    except Exception as e:
+        DATA_FILES = None
+        print('Dependency extraction failed. Please copy required files manually.')
+else:
+    DATA_FILES = None
+
+# MAIN SETUP
 setup(
     name=PACKAGE_NAME,
     version=VERSION,
@@ -71,5 +82,6 @@ setup(
     data_files = DATA_FILES,
     )
 
-if platform.system() == 'Windows':
+# PRE-INSTALLATION CELANUP
+if SIMPLE_INSTALL and platform.system() == 'Windows':
     pre_install.win_setup(cleanup=True)

--- a/setup.py
+++ b/setup.py
@@ -72,4 +72,4 @@ setup(
     )
 
 if platform.system() == 'Windows':
-    win_setup(cleanup=True)
+    pre_install.win_setup(cleanup=True)

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,9 @@
 import os
 import sys
 import re
+import pre_install
+import platform
+
 try:
     from setuptools import setup, find_packages
 except ImportError:
@@ -38,6 +41,14 @@ else:
 #HERE = os.path.abspath(os.path.dirname(__file__))
 #README = open(os.path.join(HERE, 'README.md')).read()
 
+# PRE INSTALLATION SCRIPT
+print('Running pre-installation script...')
+try:
+    DATA_FILES = pre_install.get_data_files()
+except Exception as e:
+    DATA_FILES = None
+    print('Dependency extraction failed. Please copy required files manually.')
+
 setup(
     name=PACKAGE_NAME,
     version=VERSION,
@@ -56,4 +67,9 @@ setup(
                  'Topic :: Utilities'],
     license='GPLv3',
     keywords='radio librtlsdr rtlsdr sdr',
-    packages=PACKAGES)
+    packages=PACKAGES,
+    data_files = DATA_FILES,
+    )
+
+if platform.system() == 'Windows':
+    win_setup(cleanup=True)


### PR DESCRIPTION
I created a `pre-install.py` module that downloads pre-built `rtl-sdr` libraries for Windows and copies them to the package installation directory. For Linux it installs `rtl-sdr` package from the package index. The `pre-install` module is integrated with `setup.py`.

This way, end users do not have to worry about building their own libraries but can get them updated from their sources.

This also allows the package to be used from the start from any directory without dependency errors, not just the cloned repository.
