### PR TITLE
Use third-party setup-python action

### DIFF
--- a/.github/workflows/dist-test.yml
+++ b/.github/workflows/dist-test.yml
@@ -43,7 +43,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: MatteoH2O1999/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
     - name: Build librtlsdr

--- a/.github/workflows/dist-test.yml
+++ b/.github/workflows/dist-test.yml
@@ -46,6 +46,7 @@ jobs:
       uses: MatteoH2O1999/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
+        cache-build: true
     - name: Build librtlsdr
       run: |
         sudo apt-get install -y libusb-1.0-0-dev

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -25,6 +25,7 @@ jobs:
       uses: MatteoH2O1999/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
+        cache-build: true
     - name: Build librtlsdr
       run: |
         sudo apt-get install -y libusb-1.0-0-dev

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: MatteoH2O1999/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
     - name: Build librtlsdr


### PR DESCRIPTION
Python2.7 removed from github/setup-python
as of June 19, 2023:
https://github.com/actions/setup-python/issues/672

A wrapper action was suggested in this comment:
https://github.com/actions/setup-python/issues/672#issuecomment-1582725639