### PR TITLE
Fix doc builds

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,7 +8,11 @@ build:
 
 python:
   install:
-    - requirements: requirements-rtd.txt
+    - requirements: doc/requirements.txt
+    - method: pip
+      path: .
+      extra_requirements:
+        - lib
 
 sphinx:
   configuration: doc/source/conf.py

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,3 +11,6 @@ python:
     - requirements: doc/requirements.txt
     - method: pip
       path: .
+
+sphinx:
+  configuration: doc/source/conf.py

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,12 @@
+version: 2
+
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+python:
+  install:
+    - method: pip
+      path: .

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,9 +8,7 @@ build:
 
 python:
   install:
-    - requirements: doc/requirements.txt
-    - method: pip
-      path: .
+    - requirements: requirements.rtd.txt
 
 sphinx:
   configuration: doc/source/conf.py

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,3 +14,4 @@ python:
 
 sphinx:
   configuration: doc/source/conf.py
+  fail_on_warning: true

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,7 +8,7 @@ build:
 
 python:
   install:
-    - requirements: requirements.rtd.txt
+    - requirements: requirements-rtd.txt
 
 sphinx:
   configuration: doc/source/conf.py

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,5 +8,6 @@ build:
 
 python:
   install:
+    - requirements: doc/requirements.txt
     - method: pip
       path: .

--- a/requirements-rtd.txt
+++ b/requirements-rtd.txt
@@ -1,2 +1,0 @@
--r doc/requirements.txt
--e '.[lib]'

--- a/requirements-rtd.txt
+++ b/requirements-rtd.txt
@@ -1,2 +1,2 @@
 -r doc/requirements.txt
--e .
+-e '.[lib]'

--- a/requirements-rtd.txt
+++ b/requirements-rtd.txt
@@ -1,0 +1,2 @@
+-r doc/requirements.txt
+-e .

--- a/setup.py
+++ b/setup.py
@@ -24,22 +24,6 @@ from setuptools import setup, find_packages
 PACKAGE_NAME = 'pyrtlsdr'
 VERSION = '0.3.0'
 
-BASE_DIR = os.path.dirname(os.path.abspath(__file__))
-IS_RTDBUILD = os.environ.get('READTHEDOCS', '').lower() == 'true'
-
-if IS_RTDBUILD:
-    # copy a mocked wrapper since we can't build librtlsdr on rtfd
-    def copy_mock_librtlsdr():
-        mock_src = os.path.join(BASE_DIR, 'tests', 'testlibrtlsdr.py')
-        lib_dst = os.path.join(BASE_DIR, 'rtlsdr', 'librtlsdr.py')
-        orig_lib_dst = os.path.join(BASE_DIR, 'rtlsdr', 'librtlsdr.py.orig')
-        if not os.path.exists(orig_lib_dst):
-            print(' -> '.join([lib_dst, orig_lib_dst]))
-            os.rename(lib_dst, orig_lib_dst)
-            print(' -> '.join([mock_src, lib_dst]))
-            shutil.copy(mock_src, lib_dst)
-    if 'install' in sys.argv:
-        copy_mock_librtlsdr()
 
 #HERE = os.path.abspath(os.path.dirname(__file__))
 #README = open(os.path.join(HERE, 'README.md')).read()


### PR DESCRIPTION
readthedocs now requires a config file (`.readthedocs.yaml`) in the repo for all builds

Since [pyrtlsdrlib](https://github.com/pyrtlsdr/pyrtlsdrlib) can now be installed as an [extra requirement](https://setuptools.readthedocs.io/en/latest/userguide/dependency_management.html#optional-dependencies), the [hacky code](https://github.com/pyrtlsdr/pyrtlsdr/pull/151/files#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L27-L42) in `setup.py` that was used to mock `librtlsdr` is no longer needed 