### PR TITLE
[WIP] Migrate away from legacy Python versions

### DIFF
--- a/.github/workflows/dist-test.yml
+++ b/.github/workflows/dist-test.yml
@@ -39,16 +39,9 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest ]
-        python-version: ["2.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         dist-type: [sdist, wheel]
-        exclude:
-          - os: windows-latest
-            python-version: "2.7"
-          - os: macos-latest
-            python-version: "2.7"
       fail-fast: false
-    env:
-      LD_LIBRARY_PATH: ''
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -56,22 +49,11 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
         cache-build: true
-    - name: Build librtlsdr
-      if: ${{ matrix.python-version == 2.7 }}
-      run: |
-        sudo apt-get install -y libusb-1.0-0-dev
-        cd tools/ci
-        ./install-librtlsdr.sh
-        cd ../..
-        echo "NEW_LD_LIBPATH=$HOME/.local:$LD_LIBRARY_PATH" >> $GITHUB_ENV
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        pip install -U pytest pytest-forked pytest-cov
+        pip install -U pytest pytest-forked pytest-cov pytest-asyncio
         pip install numpy
-    - name: Install py3 dependencies
-      run: pip install pytest-asyncio
-      if: ${{ matrix.python-version != 2.7 }}
     - name: Download artifacts
       uses: actions/download-artifact@v2
       with:
@@ -90,7 +72,6 @@ jobs:
       if: ${{ matrix.dist-type == 'sdist' }}
       run: pip install dist/*.tar.gz
     - name: Install pyrtlsdrlib
-      if: ${{ matrix.python-version != 2.7 }}
       run: pip install pyrtlsdrlib
     - name: Test distribution
       shell: bash
@@ -98,8 +79,6 @@ jobs:
         py.test --cov-config .coveragerc --cov=rtlsdr
         py.test --cov-append --cov-config .coveragerc --cov=rtlsdr --no-overrides --pyargs tests/no_override_client_mode.py
         py.test --cov-append --cov-config .coveragerc --cov=rtlsdr --no-overrides --pyargs tests/no_override_dll_loader.py
-      env:
-        LD_LIBRARY_PATH: ${{ env.NEW_LD_LIBPATH }}
   deploy:
     needs: test
     if: ${{ success() && (github.event.inputs.allow_deploy == 'true') }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,18 +16,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["2.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         os: [ubuntu-latest, macos-latest, windows-latest]
-
-        exclude:
-          - os: macos-latest
-            python-version: "2.7"
-          - os: windows-latest
-            python-version: "2.7"
-
       fail-fast: false
-    env:
-      LD_LIBRARY_PATH: ''
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -35,41 +26,19 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
         cache-build: true
-    - name: Build librtlsdr
-      if: ${{ matrix.python-version == 2.7 }}
-      run: |
-        sudo apt-get install -y libusb-1.0-0-dev
-        cd tools/ci
-        ./install-librtlsdr.sh
-        cd ../..
-        echo "NEW_LD_LIBPATH=$HOME/.local:$LD_LIBRARY_PATH" >> $GITHUB_ENV
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        pip install -U pytest pytest-cov
+        pip install -U pytest pytest-cov pytest-asyncio
         pip install numpy
-    - name: Install py3 dependencies
-      run: pip install pytest-asyncio
-      if: ${{ matrix.python-version != 2.7 }}
     - name: Install pyrtlsdr with lib
-      if: ${{ matrix.python-version != 2.7 }}
       run: pip install -e '.[lib]'
-    - name: Install pyrtlsdr
-      run: pip install -e .
-      if: ${{ matrix.python-version == 2.7 }}
     - name: Test with pytest
       shell: bash
       run: |
         py.test --cov-config .coveragerc --cov=rtlsdr
         py.test --cov-append --cov-config .coveragerc --cov=rtlsdr --no-overrides --pyargs tests/no_override_client_mode.py
         py.test --cov-append --cov-config .coveragerc --cov=rtlsdr --no-overrides --pyargs tests/no_override_dll_loader.py
-      env:
-        LD_LIBRARY_PATH: ${{ env.NEW_LD_LIBPATH }}
-    - name: Set up Python3 for coveralls
-      if: ${{ matrix.python-version == 2.7 }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
     - name: Upload to Coveralls
       run: |
         python -m pip install coveralls

--- a/rtlsdr/__init__.py
+++ b/rtlsdr/__init__.py
@@ -51,16 +51,12 @@ if RTLSDR_CLIENT_MODE:
     RtlSdr = None
     RtlSdrTcpServer = None
     RtlSdrAio = None
-    AIO_AVAILABLE = False
 else:
     from .librtlsdr import librtlsdr
-    from .rtlsdr import RtlSdr
-    from .rtlsdrtcp import RtlSdrTcpServer, RtlSdrTcpClient
     from .helpers import limit_calls, limit_time
-    from .rtlsdraio import RtlSdrAio, AIO_AVAILABLE
+    from .rtlsdraio import RtlSdrAio as RtlSdr
+    from .rtlsdrtcp import RtlSdrTcpServer, RtlSdrTcpClient
 
-if AIO_AVAILABLE:
-    RtlSdr = RtlSdrAio
 
 
 __all__  = ['librtlsdr', 'RtlSdr', 'RtlSdrTcpServer', 'RtlSdrTcpClient',

--- a/rtlsdr/rtlsdr.py
+++ b/rtlsdr/rtlsdr.py
@@ -24,13 +24,7 @@ from .librtlsdr import (
     tuner_bandwidth_supported,
     tuner_set_bandwidth_supported,
 )
-try:                from itertools import izip
-except ImportError: izip = zip
-import sys
 
-PY3 = sys.version_info.major >= 3
-if PY3:
-    basestring = str
 
 # see if NumPy is available
 has_numpy = True
@@ -100,7 +94,7 @@ class BaseRtlSdr(object):
         .. _rtl\_eeprom: http://manpages.ubuntu.com/manpages/trusty/man1/rtl_eeprom.1.html
 
         """
-        if PY3 and isinstance(serial, str):
+        if isinstance(serial, str):
             serial = bytes(serial, 'UTF-8')
 
         result = librtlsdr.rtlsdr_get_index_by_serial(serial)
@@ -306,7 +300,7 @@ class BaseRtlSdr(object):
         return getattr(self, '_bandwidth', 0)
 
     def set_gain(self, gain):
-        if isinstance(gain, basestring) and gain == 'auto':
+        if isinstance(gain, str) and gain == 'auto':
             # disable manual gain -> enable AGC
             self.set_manual_gain_enabled(False)
 
@@ -419,7 +413,7 @@ class BaseRtlSdr(object):
         """
 
         # convert parameter
-        if isinstance(direct, basestring):
+        if isinstance(direct, str):
             if direct.lower() == 'i':
                 direct = 1
             elif direct.lower() == 'q':
@@ -527,7 +521,7 @@ class BaseRtlSdr(object):
             iq -= (1 + 1j)
         else:
             # use normal list
-            iq = [complex(i/(255/2) - 1, q/(255/2) - 1) for i, q in izip(bytes[::2], bytes[1::2])]
+            iq = [complex(i/(255/2) - 1, q/(255/2) - 1) for i, q in zip(bytes[::2], bytes[1::2])]
 
         return iq
 

--- a/rtlsdr/rtlsdraio.py
+++ b/rtlsdr/rtlsdraio.py
@@ -29,17 +29,15 @@ Example:
 """
 
 import logging
-try:
-    import asyncio
-    AIO_AVAILABLE = True
-except ImportError:
-    AIO_AVAILABLE = False
+import asyncio
+
+
 from .rtlsdr import RtlSdr
 
 
 log = logging.getLogger(__name__)
 
-_CLASS_TEMPLATE = """
+
 class AsyncCallbackIter:
     '''Convert a callback-based legacy async function into one supporting asyncio
     and Python 3.5+
@@ -145,18 +143,7 @@ class AsyncCallbackIter:
 
         # slight hack for rtlsdr to ignore context object
         return val[0]
-"""
 
-
-if AIO_AVAILABLE:
-    try:
-        exec('async def test_for_async(): pass')
-        exec('def test_unpack_operators(a, *, b): pass')
-    except SyntaxError:
-        AIO_AVAILABLE = False
-
-if AIO_AVAILABLE:
-    exec(_CLASS_TEMPLATE, globals(), locals())
 
 class RtlSdrAio(RtlSdr):
     DEFAULT_READ_SIZE = 128*1024

--- a/rtlsdr/rtlsdrtcp/base.py
+++ b/rtlsdr/rtlsdrtcp/base.py
@@ -1,5 +1,4 @@
 from __future__ import division
-import sys
 import time
 import select
 import socket
@@ -8,10 +7,6 @@ import errno
 import traceback
 import json
 
-try:
-    from itertools import izip
-except ImportError:
-    izip = zip
 
 has_numpy = True
 try:
@@ -19,7 +14,6 @@ try:
 except ImportError:
     has_numpy = False
 
-PY2 = sys.version_info[0] == 2
 
 DEFAULT_READ_SIZE = 1024
 MAX_BUFFER_SIZE = 4096
@@ -73,7 +67,7 @@ class RtlSdrTcpBase(object):
             iq -= (1 + 1j)
         else:
             # use normal list
-            iq = [complex(i/(255/2) - 1, q/(255/2) - 1) for i, q in izip(bytes[::2], bytes[1::2])]
+            iq = [complex(i/(255/2) - 1, q/(255/2) - 1) for i, q in zip(bytes[::2], bytes[1::2])]
 
         return iq
 
@@ -118,7 +112,7 @@ class MessageBase(object):
 
     @staticmethod
     def _send(sock, data):
-        if not PY2 and isinstance(data, str):
+        if isinstance(data, str):
             data = data.encode()
         r, w, e = select.select([], [sock], [], .5)
         if sock not in w:
@@ -145,8 +139,7 @@ class MessageBase(object):
 
         """
         header = cls._recv(sock)
-        if not PY2:
-            header = header.decode()
+        header = header.decode()
         kwargs = json.loads(header)
         if kwargs.get('ACK'):
             cls = AckMessage
@@ -230,8 +223,7 @@ class ServerMessage(MessageBase):
 
         """
         header = cls._recv(sock)
-        if not PY2:
-            header = header.decode()
+        header = header.decode()
         kwargs = json.loads(header)
         struct_fmt = kwargs.get('struct_fmt')
         if struct_fmt is not None:

--- a/rtlsdr/rtlsdrtcp/server.py
+++ b/rtlsdr/rtlsdrtcp/server.py
@@ -1,15 +1,10 @@
 #! /usr/bin/env python
-import sys
 import threading
 import struct
 import traceback
 import argparse
 
-PY2 = sys.version_info[0] == 2
-if PY2:
-    from SocketServer import TCPServer, BaseRequestHandler
-else:
-    from socketserver import TCPServer, BaseRequestHandler
+from socketserver import TCPServer, BaseRequestHandler
 
 from rtlsdr import RtlSdr
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,8 +21,6 @@ classifiers =
     License :: OSI Approved :: GNU General Public License (GPL)
     Natural Language :: English
     Operating System :: OS Independent
-    Programming Language :: Python :: 2
-    Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -32,6 +30,7 @@ classifiers =
 
 [options]
 packages = find:
+python_requires = >=3.8
 
 [options.packages.find]
 exclude =

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,3 @@
-import sys
 import os
 
 import pytest
@@ -24,11 +23,6 @@ def pytest_collection_modifyitems(config, items):
 
 collect_ignore = ['setup.py', 'demo_waterfall.py']
 
-ASYNC_AVAILABLE = sys.version_info.major >= 3
-if sys.version_info.major == 3:
-    ASYNC_AVAILABLE = sys.version_info.minor >= 5
-if not ASYNC_AVAILABLE:
-    collect_ignore.append('test_aio.py')
 
 def is_travisci():
     return any([os.environ.get(key) == 'true' for key in ['CI', 'TRAVIS']])
@@ -72,7 +66,7 @@ def use_numpy(request, monkeypatch):
 
 @pytest.fixture
 def sdr_cls():
-    from rtlsdr.rtlsdr import RtlSdr
+    from rtlsdr import RtlSdr
     return RtlSdr
 
 @pytest.fixture


### PR DESCRIPTION
Targeting modern Python (`>=3.8`) will allow for cleaner code, proper typing support (planned soon) and reduce technical debt (to name a few). 

Any legacy users would still be able to install older versions of pyrtlsdr (automatically handled by setuptools `python_requires` in the metadata).

Not sure what the roadmap of this change should like, but I think it's a good time to start that discussion