### PR TITLE
refactored demo_waterfall to not use depricated libraries, runs much smoother now.

### DIFF
--- a/demo_waterfall.py
+++ b/demo_waterfall.py
@@ -17,23 +17,24 @@
 
 from __future__ import division
 import matplotlib.animation as animation
-from matplotlib.mlab import psd
-import pylab as pyl
+import matplotlib.pyplot as plt
 import numpy as np
 import sys
 from rtlsdr import RtlSdr
+from scipy.signal import welch
+from numba import jit
 
 # A simple waterfall, spectrum plotter
 #
 # Controls:
 #
 # * Scroll mouse-wheel up or down, or press the left or right arrow keys, to
-#   change the center frequency (hold shift for finer control).
+#   change the centre frequency (hold shift for finer control).
 # * Press "+" and "-" to control gain, and space to enable AGC.
-# * Type a frequency (in MHz) and press enter to directly change the center frequency
+# * Type a frequency (in MHz) and press enter to directly change the centre frequency
 
-NFFT = 1024*4
-NUM_SAMPLES_PER_SCAN = NFFT*16
+NFFT = 1024 * 4
+NUM_SAMPLES_PER_SCAN = NFFT * 16
 NUM_BUFFERED_SWEEPS = 100
 
 # change this to control the number of scans that are combined in a single sweep
@@ -45,70 +46,73 @@ FREQ_INC_COARSE = 1e6
 FREQ_INC_FINE = 0.1e6
 GAIN_INC = 5
 
-class Waterfall(object):
+
+class Waterfall:
     keyboard_buffer = []
     shift_key_down = False
-    image_buffer = -100*np.ones((NUM_BUFFERED_SWEEPS,\
-                                 NUM_SCANS_PER_SWEEP*NFFT))
+    image_buffer = -100 * np.ones((NUM_BUFFERED_SWEEPS, NUM_SCANS_PER_SWEEP * NFFT))
 
-    def __init__(self, sdr=None, fig=None):
-        self.fig = fig if fig else pyl.figure()
+    def __init__(self, sdr: RtlSdr = None, fig: plt.Figure = None):
+        self.fig = fig if fig else plt.figure()
         self.sdr = sdr if sdr else RtlSdr()
 
         self.init_plot()
 
     def init_plot(self):
-        self.ax = self.fig.add_subplot(1,1,1)
-        self.image = self.ax.imshow(self.image_buffer, aspect='auto',\
-                                    interpolation='nearest', vmin=-50, vmax=10)
-        self.ax.set_xlabel('Current frequency (MHz)')
+        self.ax = self.fig.add_subplot(1, 1, 1)
+        self.image = self.ax.imshow(
+            self.image_buffer, aspect="auto", interpolation="nearest", vmin=-50, vmax=10
+        )
+        self.ax.set_xlabel("Current frequency (MHz)")
         self.ax.get_yaxis().set_visible(False)
 
-        self.fig.canvas.mpl_connect('scroll_event', self.on_scroll)
-        self.fig.canvas.mpl_connect('key_press_event', self.on_key_press)
-        self.fig.canvas.mpl_connect('key_release_event', self.on_key_release)
+        self.fig.canvas.mpl_connect("scroll_event", self.on_scroll)
+        self.fig.canvas.mpl_connect("key_press_event", self.on_key_press)
+        self.fig.canvas.mpl_connect("key_release_event", self.on_key_release)
 
     def update_plot_labels(self):
         fc = self.sdr.fc
         rs = self.sdr.rs
-        freq_range = (fc - rs/2)/1e6, (fc + rs*(NUM_SCANS_PER_SWEEP - 0.5))/1e6
+        freq_range = (fc - rs / 2) / 1e6, (fc + rs * (NUM_SCANS_PER_SWEEP - 0.5)) / 1e6
 
         self.image.set_extent(freq_range + (0, 1))
         self.fig.canvas.draw_idle()
 
     def on_scroll(self, event):
-        if event.button == 'up':
+        if event.button == "up":
             self.sdr.fc += FREQ_INC_FINE if self.shift_key_down else FREQ_INC_COARSE
             self.update_plot_labels()
-        elif event.button == 'down':
+        elif event.button == "down":
             self.sdr.fc -= FREQ_INC_FINE if self.shift_key_down else FREQ_INC_COARSE
             self.update_plot_labels()
 
     def on_key_press(self, event):
-        if event.key == '+':
+        if event.key == "+":
             self.sdr.gain += GAIN_INC
-        elif event.key == '-':
+        elif event.key == "-":
             self.sdr.gain -= GAIN_INC
-        elif event.key == ' ':
-            self.sdr.gain = 'auto'
-        elif event.key == 'shift':
+        elif event.key == " ":
+            self.sdr.gain = "auto"
+        elif event.key == "shift":
             self.shift_key_down = True
-        elif event.key == 'right':
+        elif event.key == "right":
             self.sdr.fc += FREQ_INC_FINE if self.shift_key_down else FREQ_INC_COARSE
             self.update_plot_labels()
-        elif event.key == 'left':
+        elif event.key == "left":
             self.sdr.fc -= FREQ_INC_FINE if self.shift_key_down else FREQ_INC_COARSE
             self.update_plot_labels()
-        elif event.key == 'enter':
-            # see if valid frequency was entered, then change center frequency
+        elif event.key == "enter":
+            # see if valid frequency was entered, then change centre frequency
             try:
                 # join individual key presses into a string
-                input = ''.join(self.keyboard_buffer)
+                input_freq = "".join(self.keyboard_buffer)
 
                 # if we're doing multiple adjacent scans, we need to figure out
-                # the appropriate center freq for the leftmost scan
-                center_freq = float(input)*1e6 + (self.sdr.rs/2)*(1 - NUM_SCANS_PER_SWEEP)
-                self.sdr.fc = center_freq
+                # the appropriate centre freq for the leftmost scan
+                centre_freq = float(input_freq) * 1e6 + (self.sdr.rs / 2) * (
+                    1 - NUM_SCANS_PER_SWEEP
+                )
+                self.sdr.fc = centre_freq
 
                 self.update_plot_labels()
             except ValueError:
@@ -119,47 +123,49 @@ class Waterfall(object):
             self.keyboard_buffer.append(event.key)
 
     def on_key_release(self, event):
-        if event.key == 'shift':
+        if event.key == "shift":
             self.shift_key_down = False
 
+    @staticmethod
+    @jit(nopython=True)
+    def log10(arr):
+        result = np.empty_like(arr)
+        for i in range(arr.size):
+            result[i] = np.log10(arr[i])
+        return result
+
     def update(self, *args):
-        # save center freq. since we're gonna be changing it
+        # save centre freq. since we're gonna be changing it
         start_fc = self.sdr.fc
 
         # prepare space in buffer
-        # TODO: use indexing to avoid recreating buffer each time
         self.image_buffer = np.roll(self.image_buffer, 1, axis=0)
 
-        for scan_num, start_ind in enumerate(range(0, NUM_SCANS_PER_SWEEP*NFFT, NFFT)):
-            self.sdr.fc += self.sdr.rs*scan_num
+        for scan_num, start_ind in enumerate(
+            range(0, NUM_SCANS_PER_SWEEP * NFFT, NFFT)
+        ):
+            self.sdr.fc += self.sdr.rs * scan_num
 
             # estimate PSD for one scan
             samples = self.sdr.read_samples(NUM_SAMPLES_PER_SCAN)
-            psd_scan, f = psd(samples, NFFT=NFFT)
-
-            self.image_buffer[0, start_ind: start_ind+NFFT] = 10*np.log10(psd_scan)
+            freqs, psd_scan = welch(samples, nperseg=NFFT)
+            log_psd = self.log10(psd_scan)
+            self.image_buffer[0, start_ind : start_ind + NFFT] = 10 * log_psd
 
         # plot entire sweep
         self.image.set_array(self.image_buffer)
 
-        # restore original center freq.
+        # restore original centre freq.
         self.sdr.fc = start_fc
 
-        return self.image,
+        return (self.image,)
 
     def start(self):
         self.update_plot_labels()
-        if sys.platform == 'darwin':
-            # Disable blitting. The matplotlib.animation's restore_region()
-            # method is only implemented for the Agg-based backends,
-            # which the macosx backend is not.
-            blit = False
-        else:
-            blit = True
-        ani = animation.FuncAnimation(self.fig, self.update, interval=50,
-                blit=blit)
+        blit = not sys.platform == "darwin"
+        ani = animation.FuncAnimation(self.fig, self.update, interval=50, blit=blit)
 
-        pyl.show()
+        plt.show()
 
         return
 
@@ -179,5 +185,5 @@ def main():
     sdr.close()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
The demo waterfall app used a number of depricated libraries and techniques.

- Replaced pylab with pyplot
- Replaced psd with welch from scipy.signal.
- Used f-strings for better readability.
- Added type hints for better clarity.
- Simplified blit check for FuncAnimation.
- Refactored the loop structure to avoid unnecessary recalculations.
- Used np.roll to manage the buffer without excessive copying.
- Optimised Log Calculation using Numba to optimise the log calculation part for the PSD.
- Supressed FuncAnimation Warning. (The warning regarding cache_frame_data can be ignored or explicitly set cache_frame_data=False).
- I have left from __future__ import divsion alone.

I hope my autoformatter doesn't cause any style issues.