### PR TITLE
Reduce runtime of wheel and sdist tests

### DIFF
--- a/.github/workflows/dist-test.yml
+++ b/.github/workflows/dist-test.yml
@@ -69,10 +69,7 @@ jobs:
       run: pip install pyrtlsdrlib
     - name: Test wheel
       shell: bash
-      run: |
-        py.test --cov-config .coveragerc --cov=rtlsdr
-        py.test --cov-append --cov-config .coveragerc --cov=rtlsdr --no-overrides --pyargs tests/no_override_client_mode.py
-        py.test --cov-append --cov-config .coveragerc --cov=rtlsdr --no-overrides --pyargs tests/no_override_dll_loader.py
+      run: py.test tests/test_basic.py
 
     - name: Uninstall wheel
       shell: bash
@@ -85,10 +82,8 @@ jobs:
         pip install dist/*.tar.gz
     - name: Test sdist
       shell: bash
-      run: |
-        py.test --cov-config .coveragerc --cov=rtlsdr
-        py.test --cov-append --cov-config .coveragerc --cov=rtlsdr --no-overrides --pyargs tests/no_override_client_mode.py
-        py.test --cov-append --cov-config .coveragerc --cov=rtlsdr --no-overrides --pyargs tests/no_override_dll_loader.py
+      run: py.test tests/test_basic.py
+
   deploy:
     needs: test
     if: ${{ success() && (github.event.inputs.allow_deploy == 'true') }}


### PR DESCRIPTION
### TL;DR

Refactored the distribution testing workflow to test both wheel and sdist packages sequentially in the same job instead of using a matrix strategy.

### What changed?

- Removed the `dist-type` matrix dimension from the GitHub Actions workflow
- Modified the test job to install and test wheel packages first, then uninstall and test sdist packages
- Replaced comprehensive test coverage commands with basic tests (`py.test tests/test_basic.py`) for both distribution types
- Added explicit uninstall steps between testing different package formats

### How to test?

Run the GitHub Actions workflow to verify that both wheel and sdist packages are properly installed and tested in sequence on all supported operating systems and Python versions.

### Why make this change?

This change simplifies the testing matrix while ensuring both distribution formats are still validated, potentially reducing CI job complexity and execution time by eliminating duplicate jobs.