### PR TITLE
Use Blacksmith macOS runners in CI jobs

### DIFF
--- a/.github/workflows/dist-test.yml
+++ b/.github/workflows/dist-test.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [blacksmith-2vcpu-ubuntu-2204, macos-latest, blacksmith-2vcpu-windows-2025 ]
+        os: [blacksmith-2vcpu-ubuntu-2204, blacksmith-6vcpu-macos-latest, blacksmith-2vcpu-windows-2025 ]
         python-version: ["3.8", "3.9", "3.10", "3.11"]
       fail-fast: false
     steps:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
-        os: [blacksmith-2vcpu-ubuntu-2204, macos-latest, blacksmith-2vcpu-windows-2025]
+        os: [blacksmith-2vcpu-ubuntu-2204, blacksmith-6vcpu-macos-latest, blacksmith-2vcpu-windows-2025]
       fail-fast: false
     steps:
     - uses: actions/checkout@v6


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD testing infrastructure configuration for improved build performance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pyrtlsdr/pyrtlsdr/pull/205?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->