### PR TITLE
Remove setuptools dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,6 @@ testpaths = ["tests"]
 [dependency-groups]
 lib = [
     "pyrtlsdrlib>=0.0.4",
-    "setuptools; python_version < '3.9'",
 ]
 test = [
     {include-group = "lib"},

--- a/uv.lock
+++ b/uv.lock
@@ -1401,7 +1401,6 @@ dev = [
     { name = "pytest-cov", version = "5.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "pytest-cov", version = "7.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
     { name = "pytest-forked" },
-    { name = "setuptools", marker = "python_full_version < '3.9'" },
     { name = "sphinx", version = "7.1.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
     { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
@@ -1419,7 +1418,6 @@ doc = [
     { name = "myst-parser", version = "4.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
     { name = "myst-parser", version = "5.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pyrtlsdrlib" },
-    { name = "setuptools", marker = "python_full_version < '3.9'" },
     { name = "sphinx", version = "7.1.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
     { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
@@ -1432,7 +1430,6 @@ doc = [
 ]
 lib = [
     { name = "pyrtlsdrlib" },
-    { name = "setuptools", marker = "python_full_version < '3.9'" },
 ]
 test = [
     { name = "numpy", version = "1.24.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
@@ -1449,7 +1446,6 @@ test = [
     { name = "pytest-cov", version = "5.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "pytest-cov", version = "7.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
     { name = "pytest-forked" },
-    { name = "setuptools", marker = "python_full_version < '3.9'" },
 ]
 
 [package.metadata]
@@ -1466,7 +1462,6 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=0.24.0" },
     { name = "pytest-cov", specifier = ">=5.0.0" },
     { name = "pytest-forked", specifier = ">=1.6.0" },
-    { name = "setuptools", marker = "python_full_version < '3.9'" },
     { name = "sphinx", specifier = ">=7.1.2" },
     { name = "sphinx-design", specifier = ">=0.5.0" },
     { name = "sphinx-rtd-theme", specifier = ">=3.1.0" },
@@ -1475,15 +1470,11 @@ doc = [
     { name = "linkify-it-py", specifier = ">=2.0.3" },
     { name = "myst-parser", specifier = ">=3.0.1" },
     { name = "pyrtlsdrlib", specifier = ">=0.0.4" },
-    { name = "setuptools", marker = "python_full_version < '3.9'" },
     { name = "sphinx", specifier = ">=7.1.2" },
     { name = "sphinx-design", specifier = ">=0.5.0" },
     { name = "sphinx-rtd-theme", specifier = ">=3.1.0" },
 ]
-lib = [
-    { name = "pyrtlsdrlib", specifier = ">=0.0.4" },
-    { name = "setuptools", marker = "python_full_version < '3.9'" },
-]
+lib = [{ name = "pyrtlsdrlib", specifier = ">=0.0.4" }]
 test = [
     { name = "numpy", specifier = ">=1.24.4" },
     { name = "pyrtlsdrlib", specifier = ">=0.0.4" },
@@ -1491,7 +1482,6 @@ test = [
     { name = "pytest-asyncio", specifier = ">=0.24.0" },
     { name = "pytest-cov", specifier = ">=5.0.0" },
     { name = "pytest-forked", specifier = ">=1.6.0" },
-    { name = "setuptools", marker = "python_full_version < '3.9'" },
 ]
 
 [[package]]
@@ -1829,15 +1819,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ae/f9/41dc953bbeb056c17d5f7a519f50fdf010bd0553be2d630bc69d1e022703/roman_numerals-4.1.0.tar.gz", hash = "sha256:1af8b147eb1405d5839e78aeb93131690495fe9da5c91856cb33ad55a7f1e5b2", size = 9077, upload-time = "2025-12-17T18:25:34.381Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/54/6f679c435d28e0a568d8e8a7c0a93a09010818634c3c3907fc98d8983770/roman_numerals-4.1.0-py3-none-any.whl", hash = "sha256:647ba99caddc2cc1e55a51e4360689115551bf4476d90e8162cf8c345fe233c7", size = 7676, upload-time = "2025-12-17T18:25:33.098Z" },
-]
-
-[[package]]
-name = "setuptools"
-version = "75.3.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0e/93/d2622cbf262418995140dfc1ddb890badd6322893fa122302577c82b9617/setuptools-75.3.4.tar.gz", hash = "sha256:b4ea3f76e1633c4d2d422a5d68ab35fd35402ad71e6acaa5d7e5956eb47e8887", size = 1354595, upload-time = "2026-02-08T14:12:34.287Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cd/b1/961ba076c7d3732e3a97e6681c55ef647afb795fe8bfcd27becec8a762ce/setuptools-75.3.4-py3-none-any.whl", hash = "sha256:2dd50a7f42dddfa1d02a36f275dbe716f38ed250224f609d35fb60a09593d93e", size = 1251633, upload-time = "2026-02-08T14:12:32.364Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This was added in 6a47ae3 for compatibility with [pyrtlsdrlib](https://github.com/pyrtlsdr/pyrtlsdrlib) which relied on `pkg_resources`.  

That was addressed in pyrtlsdrlib at a741863 and released in [v0.0.4](https://github.com/pyrtlsdr/pyrtlsdrlib/releases/tag/0.0.4) so this should no longer be necessary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed legacy conditional dependency for older Python versions, simplifying the dependency configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pyrtlsdr/pyrtlsdr/pull/207?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->