### PR TITLE
Simplify distribution tests

### DIFF
--- a/.github/workflows/dist-test.yml
+++ b/.github/workflows/dist-test.yml
@@ -65,13 +65,6 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-      # Note: We're exporting the lockfile without the project or its direct dependencies included.
-      # Then we avoid using uv elsewhere to ensure we're testing the installed package
-      # and not the development environment.
-    - name: Export Lockfile
-      run: uv export --frozen --only-group test --only-group doc --format requirements-txt -o requirements.txt
-    - name: Install dependencies
-      run: pip install -r requirements.txt
     - name: Download artifacts
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
@@ -81,25 +74,11 @@ jobs:
       shell: bash
       run: |
         rm -Rf rtlsdr
-    - name: Install wheel
-      shell: bash
-      run: pip install dist/*.whl
+    # Test the built distributions in isolated environments to ensure they're packaged properly
     - name: Test wheel
-      shell: bash
-      run: py.test tests/test_basic.py
-
-    - name: Uninstall wheel
-      shell: bash
-      run: |
-        pip uninstall -y pyrtlsdr
-    - name: Install sdist
-      shell: bash
-      run: |
-        pip uninstall -y pyrtlsdr
-        pip install dist/*.tar.gz
+      run: uv run --isolated --no-project --with pyrtlsdrlib --with dist/*.whl smoke_test.py
     - name: Test sdist
-      shell: bash
-      run: py.test tests/test_basic.py
+      run: uv run --isolated --no-project --with pyrtlsdrlib --with dist/*.tar.gz smoke_test.py
 
   deploy:
     needs: test

--- a/.github/workflows/dist-test.yml
+++ b/.github/workflows/dist-test.yml
@@ -76,8 +76,10 @@ jobs:
         rm -Rf rtlsdr
     # Test the built distributions in isolated environments to ensure they're packaged properly
     - name: Test wheel
+      shell: bash
       run: uv run --isolated --no-project --with pyrtlsdrlib --with dist/*.whl smoke_test.py
     - name: Test sdist
+      shell: bash
       run: uv run --isolated --no-project --with pyrtlsdrlib --with dist/*.tar.gz smoke_test.py
 
   deploy:

--- a/smoke_test.py
+++ b/smoke_test.py
@@ -4,12 +4,16 @@ Simple smoke test to verify packaging without requiring a full test suite run.
 This test is run in `.github/workflows/dist-test.yml` to verify that the package
 can be installed from a wheel and used in a clean environment.
 """
+import sys
 from pathlib import Path
 
 HERE = Path(__file__).resolve().parent
 
 
 def test_pkg_version():
+    if sys.version_info < (3, 11):
+        print("Skipping test_pkg_version: tomllib is only available in python 3.11 and above")
+        return
     import rtlsdr
     import tomllib
 

--- a/smoke_test.py
+++ b/smoke_test.py
@@ -1,0 +1,36 @@
+"""
+Simple smoke test to verify packaging without requiring a full test suite run.
+
+This test is run in `.github/workflows/dist-test.yml` to verify that the package
+can be installed from a wheel and used in a clean environment.
+"""
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+
+
+def test_pkg_version():
+    import rtlsdr
+    import tomllib
+
+    pyproject_fn = HERE / 'pyproject.toml'
+    assert pyproject_fn.exists()
+    pyproject = tomllib.loads(pyproject_fn.read_text())
+    pyproject_version = pyproject['project']['version']
+    assert rtlsdr.__version__ == pyproject_version
+
+
+
+def test_import_is_not_from_source():
+    import rtlsdr
+    src_dir = HERE / "rtlsdr"
+    pkg_dir = Path(rtlsdr.__file__).resolve().parent
+    assert pkg_dir != src_dir, (
+        f"package is being imported from source directory {src_dir}, "
+        f"but should be imported from installed package {pkg_dir}"
+    )
+
+
+if __name__ == "__main__":
+    test_pkg_version()
+    test_import_is_not_from_source()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added lightweight packaging smoke tests to verify the installed package version matches the declared version and that the package is imported from the built artifact rather than local source.
* **Chores**
  * Updated the build verification workflow to run smoke tests against the built wheel and sdist in an isolated environment, replacing the previous installation/uninstallation and basic test execution approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->