### PR TITLE
Migrate from coveralls to codecov

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -59,3 +59,7 @@ jobs:
       uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+        env_vars: OS,PYTHON
+      env:
+        OS: ${{ matrix.os }}
+        PYTHON: ${{ matrix.python-version }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -51,9 +51,8 @@ jobs:
         uv run pytest --cov-config .coveragerc --cov=rtlsdr
         uv run pytest --cov-append --cov-config .coveragerc --cov=rtlsdr --no-overrides --pyargs tests/no_override_client_mode.py
         uv run pytest --cov-append --cov-config .coveragerc --cov=rtlsdr --no-overrides --pyargs tests/no_override_dll_loader.py
-    - name: Combine coverage and generate report
+    - name: Generate coverage reports
       run: |
-        uv run coverage combine
         uv run coverage report
         uv run coverage xml
     - name: Upload coverage reports to Codecov

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -51,26 +51,12 @@ jobs:
         uv run pytest --cov-config .coveragerc --cov=rtlsdr
         uv run pytest --cov-append --cov-config .coveragerc --cov=rtlsdr --no-overrides --pyargs tests/no_override_client_mode.py
         uv run pytest --cov-append --cov-config .coveragerc --cov=rtlsdr --no-overrides --pyargs tests/no_override_dll_loader.py
-    - name: Upload to Coveralls
+    - name: Combine coverage and generate report
       run: |
-        uv pip install coveralls
-        uv run python -m coveralls --service=github
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        COVERALLS_FLAG_NAME: run-${{ matrix.python-version }}
-        COVERALLS_PARALLEL: true
-
-  coveralls:
-    name: Indicate completion to coveralls.io
-    needs: test
-    runs-on: blacksmith-2vcpu-ubuntu-2404
-    permissions:
-      contents: read
-    container: python:3-slim@sha256:b877e50bd90de10af8d82c57a022fc2e0dc731c5320d762a27986facfc3355c1
-    steps:
-    - name: Finished
-      run: |
-        pip3 install --upgrade coveralls
-        coveralls --finish
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uv run coverage combine
+        uv run coverage report
+        uv run coverage xml
+    - name: Upload coverage reports to Codecov
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the test workflow to publish coverage results through Codecov instead of Coveralls.
  * Simplified post-test coverage handling by generating coverage HTML/XML and uploading in a single step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->